### PR TITLE
Use isohybrid to make iso bootable with dd / Etcher

### DIFF
--- a/add-firmware-to
+++ b/add-firmware-to
@@ -142,6 +142,9 @@ if is_initrd "$file"; then
     initrd_append_fw "$file" "$fwfile" "$outfile"
 fi
 
+# Add MBR/EFI stuff to make iso bootable with dd / Etcher ...
+isohybrid $outfile
+
 echo "Output in $outfile"
 
 rm "$fwfile"


### PR DESCRIPTION
As found here : http://www.syslinux.org/wiki/index.php?title=Isohybrid

Just applying this command on a given iso file adds a few ko corresponding the MBR / EFI stuff, making the iso bootable when used with dd or Etcher (and still being bootable with Virtualbox)