### PR TITLE
[fix] Make iso work again for virtualmachine

### DIFF
--- a/profiles/default.preseed
+++ b/profiles/default.preseed
@@ -96,7 +96,7 @@ debconf debconf/frontend select Noninteractive
 ### Boot loader installation
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
-d-i grub-installer/bootdev string /dev/sda
+d-i grub-installer/bootdev string default
 
 ### Finishing up the installation
 d-i finish-install/reboot_in_progress note

--- a/profiles/expert.preseed
+++ b/profiles/expert.preseed
@@ -97,7 +97,7 @@ debconf debconf/frontend select Noninteractive
 ### Boot loader installation
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
-#d-i grub-installer/bootdev string /dev/sda
+#d-i grub-installer/bootdev string default
 
 ### Finishing up the installation
 d-i finish-install/reboot_in_progress note


### PR DESCRIPTION
## The problem
About grub install, we can't be sure /dev/sda exists and is the good device. It could be /dev/vda or other things.

## The solution
It seems a "default" option exists https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=759737

## State
Untested